### PR TITLE
fix: clarify diarization model default

### DIFF
--- a/app.py
+++ b/app.py
@@ -490,7 +490,7 @@ def common_form_params(
     diarization_model: str | None = Form(
         None,
         description="Override diarization model (e.g. 'pyannote/speaker-diarization-3.1'). "
-                    "Defaults to env DIARIZATION_MODEL or pyannote/3.1"
+                    "Defaults to env DIARIZATION_MODEL or 'pyannote/speaker-diarization-3.1'"
     ),
 ):
     return dict(


### PR DESCRIPTION
## Summary
- document default diarization model as `pyannote/speaker-diarization-3.1`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab55a1efd883268b72530d9b7da630